### PR TITLE
Fix guestfs_index.yaml syntax

### DIFF
--- a/.github/workflows/guestfs_index.yaml
+++ b/.github/workflows/guestfs_index.yaml
@@ -84,3 +84,4 @@ jobs:
               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               --url "https://api.github.com/repos/${{ github.repository }}/issues/4"
               --data '{"state":"closed"}'
+...


### PR DESCRIPTION
The file has an opening `---` but is missing the closing `...`.

[The spec says these are optional,](https://yaml.org/spec/1.2/spec.html#id2760395) but I think they should both be included, just to be sure.