### PR TITLE
Add dummy job to guestfs_index workflow so that its status isn't marked as failing

### DIFF
--- a/.github/workflows/guestfs_index.yaml
+++ b/.github/workflows/guestfs_index.yaml
@@ -20,7 +20,7 @@ jobs:
           echo "This job is included because GitHub Actions marks the workflow as having "\
                "'failed at startup' if no jobs are run, and the other job in this workflow "\
                "is likely to be skipped"
-          python -c "import os;print(os.environ['GITHUB_EVENT'])"
+          python3 -c "import os;print(os.environ['GITHUB_EVENT'])"
 
 
   generate_guestfs:

--- a/.github/workflows/guestfs_index.yaml
+++ b/.github/workflows/guestfs_index.yaml
@@ -13,11 +13,14 @@ jobs:
       shell: bash
     steps:
       - name: Always run
+        env:
+          GITHUB_EVENT: "${{ github.event }}"
         # NOTE:BUG https://github.community/t/workflow-is-failing-if-no-job-can-be-ran-due-to-condition/16873/2
         run: |
           echo "This job is included because GitHub Actions marks the workflow as having "\
                "'failed at startup' if no jobs are run, and the other job in this workflow "\
                "is likely to be skipped"
+          python -c "import os;print(os.environ['GITHUB_EVENT'])"
 
 
   generate_guestfs:

--- a/.github/workflows/guestfs_index.yaml
+++ b/.github/workflows/guestfs_index.yaml
@@ -7,6 +7,19 @@ on:
     types: [created]
 
 jobs:
+  always_run:
+    runs-on: ubuntu-latest
+    defaults:
+      shell: bash
+    steps:
+      - name: Always run
+        # NOTE:BUG https://github.community/t/workflow-is-failing-if-no-job-can-be-ran-due-to-condition/16873/2
+        run: |
+          echo "This job is included because GitHub Actions marks the workflow as having "\
+               "'failed at startup' if no jobs are run, and the other job in this workflow "\
+               "is likely to be skipped"
+
+
   generate_guestfs:
     name: Generate guestfs index
     if: "(github.event.id == 4 && github.event.body == 'Please update the guestfs index.')"


### PR DESCRIPTION
Currently, there are two errors:

- The workflow is marked as failing because no jobs are being run
- No jobs are being run even though they should be

The first one is fixed by adding a dummy job that always runs.

The second one is because [the conditional][] isn't triggering, and can be introspected with some print debugging added in the dummy job.

[the conditional]: <https://github.com/mawillcockson/utilities/blob/62cbf88084acc55bcda02d891513518d7cdbb38c/.github/workflows/guestfs_index.yaml#L28> "the line in the workflow file with the conditional"